### PR TITLE
release.nix: actually use provided nixpkgs

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,13 @@
-{ nixpkgs ? import <nixpkgs> {} }:
+let
+  defaultNixpkgs = import
+    (builtins.fetchTarball {
+      url = "https://github.com/nixos/nixpkgs/tarball/2cf9db0e3d45b9d00f16f2836cb1297bcadc475e";
+      sha256 = "0sij1a5hlbigwcgx10dkw6mdbjva40wzz4scn0wchv7yyi9ph48l";
+    })
+    { };
+in
+
+{ nixpkgs ? defaultNixpkgs }:
 
 let
   servant-pagination-overlay = final: prev:
@@ -14,12 +23,7 @@ let
       };
     };
 
-  _nixpkgs = import (nixpkgs.fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "2cf9db0e3d45b9d00f16f2836cb1297bcadc475e";
-    sha256 = "0sij1a5hlbigwcgx10dkw6mdbjva40wzz4scn0wchv7yyi9ph48l";
-  }) { overlays = [ servant-pagination-overlay ]; };
+  _nixpkgs = nixpkgs.extend servant-pagination-overlay;
 in
 
 with _nixpkgs;


### PR DESCRIPTION
Previously provided nixpkgs was discarded, but I really need that for seabug. This should have the same behaviour but actually use the provided nixpkgs if one is specified.