### PR TITLE
Make 'upload-image' error more verbose.

### DIFF
--- a/src/Api/Handler.hs
+++ b/src/Api/Handler.hs
@@ -95,9 +95,10 @@ handlers = Routes{..}
                 IpfsNftDbEnv env' -> Ipfs.ipfsAdd env'
                 NftStorageNftDbEnv env' key -> NftStorage.nftStorageAdd env' key
 
-        Ipfs.CID ipfsHash <- saveNftInDb imgData >>= \case
-            Right h -> pure h
-            Left e -> throwJsonError err500 (JsonError $ "Error adding image to DB: " <> Text.pack e)
+        Ipfs.CID ipfsHash <-
+            saveNftInDb imgData >>= \case
+                Right h -> pure h
+                Left e -> throwJsonError err500 (JsonError $ "Error adding image to DB: " <> Text.pack e)
 
         currentTime <- liftIO getCurrentTime
         liftIO $

--- a/src/Api/Handler.hs
+++ b/src/Api/Handler.hs
@@ -95,7 +95,9 @@ handlers = Routes{..}
                 IpfsNftDbEnv env' -> Ipfs.ipfsAdd env'
                 NftStorageNftDbEnv env' key -> NftStorage.nftStorageAdd env' key
 
-        Ipfs.CID ipfsHash <- saveNftInDb imgData >>= maybe (throwJsonError err500 (JsonError "Error adding image to DB")) pure
+        Ipfs.CID ipfsHash <- saveNftInDb imgData >>= \case
+            Right h -> pure h
+            Left e -> throwJsonError err500 (JsonError $ "Error adding image to DB: " <> Text.pack e)
 
         currentTime <- liftIO getCurrentTime
         liftIO $

--- a/src/Ipfs.hs
+++ b/src/Ipfs.hs
@@ -29,12 +29,13 @@ ipfsAdd envIpfsClientEnv fileContents = do
             let msg = "Error making an ipfs client request: " <> show e
             liftIO $ putStrLn msg
             pure $ Left msg
-        Right (Object obj) | Just (String hash) <- obj HM.!? ("Hash" :: Text)
-            -> pure . Right $ CID hash
+        Right (Object obj)
+            | Just (String hash) <- obj HM.!? ("Hash" :: Text) ->
+                pure . Right $ CID hash
         Right json -> do
-          let msg = "Error making an ipfs client request: wrong response format: " <> show json
-          liftIO $ putStrLn msg
-          pure $ Left msg
+            let msg = "Error making an ipfs client request: wrong response format: " <> show json
+            liftIO $ putStrLn msg
+            pure $ Left msg
   where
     ipfsClientAdd = client ipfsAddApi
 

--- a/src/NftStorage.hs
+++ b/src/NftStorage.hs
@@ -42,7 +42,7 @@ type NftStorageApi =
 nftStorageApi :: Proxy NftStorageApi
 nftStorageApi = Proxy
 
-nftStorageAdd :: ClientEnv -> String -> BS.ByteString -> App (Maybe CID)
+nftStorageAdd :: ClientEnv -> String -> BS.ByteString -> App (Either String CID)
 nftStorageAdd nftStorageClientEnv apiKey fileContents = do
     result <- liftIO $ runClientM query nftStorageClientEnv
     let result' = do
@@ -59,8 +59,8 @@ nftStorageAdd nftStorageClientEnv apiKey fileContents = do
     case result' of
         Left e -> do
             liftIO $ putStrLn e
-            pure Nothing
-        Right v -> pure $ pure $ CID v
+            pure $ Left e
+        Right v -> pure $ Right $ CID v
   where
     nftStorageClient = client nftStorageApi
     query = nftStorageClient fileContents (pure ("Bearer " <> apiKey))


### PR DESCRIPTION
Instead of `{"error": "Error adding image to DB"}` 

Return in request:
`{"error":"Error adding image to DB: Error making an nft.storage client request: ConnectionError (HttpExceptionRequest Request {\n host = \"api.nft.storage\"\n port = 443\n secure = True\n requestHeaders = [(\"Accept\",\"application/json;charset=utf-8,application/json\"),(\"Content-Type\",\"image/png\"),(\"Authorization\",\"<REDACTED>\")]\n path = \"/upload\"\n queryString = \"\"\n method = \"POST\"\n proxy = Nothing\n rawBody = False\n redirectCount = 10\n responseTimeout = ResponseTimeoutDefault\n requestVersion = HTTP/1.1\n}\n (InternalException (HandshakeFailed (Error_Protocol (\"certificate has unknown CA\",True,UnknownCa)))))"}`