### PR TITLE
Add default.nix for seabug's arion-compose.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url =
+        "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }).defaultNix


### PR DESCRIPTION
Closes #35. Seabug needs this as it is not flake-ified yet